### PR TITLE
[FEAT] #22 - 공통 UI객체 작성(UISearchBar, TableView)

### DIFF
--- a/WeatherWhat/WeatherWhat/View/AutoCompleteCell.swift
+++ b/WeatherWhat/WeatherWhat/View/AutoCompleteCell.swift
@@ -1,0 +1,47 @@
+//
+//  AutoCompleteCell.swift
+//  WeatherWhat
+//
+//  Created by Lee on 5/24/25.
+//
+
+import UIKit
+
+class AutoCompleteCell: UITableViewCell {
+
+    private let label = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureUI() {
+        [label].forEach {
+            self.contentView.addSubview($0)
+        }
+
+        label.font = .suit(.regular, size: 15)
+        label.textColor = .pureBlack
+
+        self.backgroundColor = .clear
+    }
+
+    func setConstraints() {
+        label.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview()
+            make.leading.equalToSuperview().offset(11)
+            make.trailing.equalToSuperview().offset(11)
+        }
+    }
+
+    // 자동완성 모델의 데이터를 받아오면 되고, 임시로 UserLocationData로 입력
+    func configureCell(data: UserLocationData) {
+        label.text = data.address
+    }
+}

--- a/WeatherWhat/WeatherWhat/View/LocationHistoryCell.swift
+++ b/WeatherWhat/WeatherWhat/View/LocationHistoryCell.swift
@@ -1,0 +1,38 @@
+//
+//  LocationHistoryCel.swift
+//  WeatherWhat
+//
+//  Created by Lee on 5/24/25.
+//
+
+import UIKit
+
+class LocationHistoryCell: UITableViewCell {
+
+    let searchLogCustomView = SearchLogCustomView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureUI() {
+        self.contentView.addSubview(searchLogCustomView)
+        self.backgroundColor = .clear
+    }
+
+    func setConstraints() {
+        searchLogCustomView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    func configureCell(data: LocationHistory, indexPath: IndexPath) {
+        searchLogCustomView.label.text = data.history[indexPath.row].address
+    }
+}

--- a/WeatherWhat/WeatherWhat/View/SearchLogCustomView.swift
+++ b/WeatherWhat/WeatherWhat/View/SearchLogCustomView.swift
@@ -1,0 +1,48 @@
+//
+//  SearchLogCustomView.swift
+//  WeatherWhat
+//
+//  Created by Lee on 5/24/25.
+//
+
+import UIKit
+
+class SearchLogCustomView: UIView {
+
+    let label = UILabel()
+    let cancelButton = UIButton()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configureUI() {
+        [label, cancelButton].forEach {
+            self.addSubview($0)
+        }
+
+        label.font = .suit(.regular, size: 13)
+        label.textColor = .pureBlack
+
+        cancelButton.setImage(UIImage(named: "deleteIcon"), for: .normal)
+    }
+
+    private func setConstraints() {
+        label.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(14)
+            make.centerY.equalToSuperview()
+        }
+
+        cancelButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-14)
+            make.centerY.equalToSuperview()
+            make.size.equalTo(10)
+        }
+    }
+}

--- a/WeatherWhat/WeatherWhat/View/SearchView.swift
+++ b/WeatherWhat/WeatherWhat/View/SearchView.swift
@@ -1,0 +1,71 @@
+//
+//  SearchView.swift
+//  WeatherWhat
+//
+//  Created by Lee on 5/24/25.
+//
+
+import UIKit
+import SnapKit
+import RxCocoa
+import RxSwift
+
+final class SearchView: UIView {
+
+    let searchBar = UISearchBar()
+    let historyTableView = UITableView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureUI()
+        setConstraints()
+    }
+
+    private func configureUI() {
+        [historyTableView, searchBar].forEach {
+            self.addSubview($0)
+        }
+
+        historyTableView.backgroundColor = .subBlue
+        historyTableView.layer.cornerRadius = 13
+        historyTableView.contentInset = .init(top: 30, left: 0, bottom: 0, right: 0)
+
+        searchBar.showsCancelButton = false
+        searchBar.searchTextField.backgroundColor = .pureWhite
+        searchBar.layer.borderWidth = 2
+        searchBar.layer.cornerRadius = 10
+        searchBar.placeholder = "위치를 입력해주세요."
+        searchBar.searchTextField.font = .suit(.regular, size: 15)
+        searchBar.layer.masksToBounds = true
+        searchBar.layer.borderColor = UIColor.mainBlue.cgColor
+    }
+
+    private func setConstraints() {
+        searchBar.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(40)
+        }
+
+        historyTableView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalTo(searchBar.snp.bottom).inset(30)
+        }
+    }
+
+    func showHistoryView(_ isVisible: Bool) {
+        historyTableView.isHidden = !isVisible
+    }
+
+}
+
+extension Reactive where Base: SearchView {
+    var searchText: ControlProperty<String?> {
+        return base.searchBar.rx.text
+    }
+}


### PR DESCRIPTION

초기화면 및 검색화면에서 사용하는 UISearchBar를 구현하였습니다.
해당 SearchBar에서 검색 기록을 표시하는 UITableView를 구현하였습니다.

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #22

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 공통 UI 객체(UISearchBar, UITableView)를 추가하였습니다.
![이미지](https://github.com/user-attachments/assets/e3590d51-9f11-4560-8597-6f5bbcdd8081)

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- SearchBar의 text 상태 변화에 반응하기 위해 rx를 추가해두었습니다. (extension Reactive where Base: SearchView)
- showHistoryView 메서드는 검색화면에서 TableView hidden 처리를 할 때 사용하는 메서드입니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- TableView의 top inset을 30으로 잡아서 SearchBar 안쪽으로 들어가게 설정해두었습니다.
- TableView의 contentsInset을 30으로 잡아서 안쪽으로 들어간 부분은 제외하고 contents가 뜨도록 구현하였습니다.

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
