### PR TITLE
[Feat] #30 - 검색화면 삭제 기능 구현, 접근제어자 추가

### DIFF
--- a/WeatherWhat/WeatherWhat/View/AutoCompleteCell.swift
+++ b/WeatherWhat/WeatherWhat/View/AutoCompleteCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class AutoCompleteCell: UITableViewCell {
+final class AutoCompleteCell: UITableViewCell {
 
     private let label = UILabel()
 
@@ -21,7 +21,7 @@ class AutoCompleteCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configureUI() {
+    private func configureUI() {
         [label].forEach {
             self.contentView.addSubview($0)
         }
@@ -32,7 +32,7 @@ class AutoCompleteCell: UITableViewCell {
         self.backgroundColor = .clear
     }
 
-    func setConstraints() {
+    private func setConstraints() {
         label.snp.makeConstraints { make in
             make.top.bottom.equalToSuperview()
             make.leading.equalToSuperview().offset(11)

--- a/WeatherWhat/WeatherWhat/View/LocationHistoryCell.swift
+++ b/WeatherWhat/WeatherWhat/View/LocationHistoryCell.swift
@@ -9,12 +9,12 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-class LocationHistoryCell: UITableViewCell {
+final class LocationHistoryCell: UITableViewCell {
 
-    let label = UILabel()
+    private let label = UILabel()
     let cancelButton = UIButton()
 
-    let disposeBag = DisposeBag()
+    var disposeBag = DisposeBag()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -26,7 +26,7 @@ class LocationHistoryCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configureUI() {
+    private func configureUI() {
         self.backgroundColor = .clear
 
         [label, cancelButton].forEach {

--- a/WeatherWhat/WeatherWhat/View/SearchView.swift
+++ b/WeatherWhat/WeatherWhat/View/SearchView.swift
@@ -15,6 +15,8 @@ final class SearchView: UIView {
     let searchBar = UISearchBar()
     let tableView = UITableView()
 
+    private let imageView = UIImageView()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #30

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 검색화면의 UI를 추가하였습니다. backButton, 검색 타이틀 추가
- 검색화면의 삭제기능을 구현하였습니다. 
   * TableView가 historyTableView일 때 해당 index에 접근하여 데이터를 삭제처리하도록 구현하였습니다.
- 접근제어자를 추가하였습니다. 누락된 접근제어자를 추가하였습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 initialView에서 userDefaults에 currentData만 저장하여, SearchView에서 해당 데이터를 불러오지 못하는 현상이 있습니다.
   * 수정 예정입니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
